### PR TITLE
Fix metric pointer reference

### DIFF
--- a/reporter.go
+++ b/reporter.go
@@ -79,11 +79,11 @@ func (c *reporter) GetMetricsResults(metrics []types.Metric) ([]types.MetricData
 		metricDataQueries = make([]types.MetricDataQuery, len(metrics))
 	)
 
-	for i, metric := range metrics {
+	for i := range metrics {
 		metricDataQueries[i] = types.MetricDataQuery{
 			Id: aws.String("n" + strconv.Itoa(i)),
 			MetricStat: &types.MetricStat{
-				Metric: &metric,
+				Metric: &metrics[i],
 				Period: &c.config.period,
 				Stat:   &c.config.stat,
 			},


### PR DESCRIPTION
I was noticing that all the metric values were the same for a Kinesis query:

Before:
```
aws_kinesis_put_records_success{stream_name="observability-error-stream"} 1
aws_kinesis_put_records_success{stream_name="upshot-aggregated-metrics"} 1
aws_kinesis_put_records_success{stream_name="upshot-aggregated-metrics-dev"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_errors"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_resque"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans_http_request"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans_trace"} 1
```

I believe it is because the `metric` in `range` is a pointer that changes per loop iteration so we'd just be requesting the same metric. See https://stackoverflow.com/questions/20185511/range-references-instead-values

After:
```
aws_kinesis_put_records_success{stream_name="observability-error-stream"} 0.9999417351278914
aws_kinesis_put_records_success{stream_name="upshot-aggregated-metrics"} 0.6399653183725004
aws_kinesis_put_records_success{stream_name="upshot-aggregated-metrics-dev"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_errors"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_resque"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans_http_request"} 1
aws_kinesis_put_records_success{stream_name="upshot_instrumentation_spans_trace"} 1
```